### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/dnc-debug.py
+++ b/dnc-debug.py
@@ -10,6 +10,12 @@ from random import uniform
 #import matplotlib.pyplot as plt
 from multiprocessing import Process, Value, Lock
 import time
+
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 def sigmoid(x): return 1.0 / (1.0 + np.exp(-x))
 def fun_key_simil(C, K): return np.dot(C, K)
 def dfun_key_simil(C, dsim): return np.dot(C.T, dsim)

--- a/dnc-numpy.py
+++ b/dnc-numpy.py
@@ -14,6 +14,11 @@ import datetime, time
 import random
 from random import uniform
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 def sigmoid(x): return 1.0 / (1.0 + np.exp(-x))
 
 ### parse args

--- a/lstm-numpy.py
+++ b/lstm-numpy.py
@@ -8,6 +8,11 @@ import datetime, time
 import random
 from random import uniform
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 def sigmoid(x): return 1.0 / (1.0 + np.exp(-x))
 
 ### parse args

--- a/rnn-numpy.py
+++ b/rnn-numpy.py
@@ -9,6 +9,11 @@ import datetime, time
 import random
 from random import uniform
 
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 ### parse args
 parser = argparse.ArgumentParser(description='')
 parser.add_argument('--batchsize', type=int, default = 16, help='batch size')


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.  This PR provides equivalent functionality in both Python 2 and Python 3.